### PR TITLE
Decoupling Frequency processing from parsing

### DIFF
--- a/src/main/java/com/google/netpcapanalysis/dao/FrequencyDaoImpl.java
+++ b/src/main/java/com/google/netpcapanalysis/dao/FrequencyDaoImpl.java
@@ -33,18 +33,16 @@ public class FrequencyDaoImpl implements FrequencyDao {
   private ArrayList<PCAPdata> allPCAP = new ArrayList<PCAPdata>(); 
   private ArrayList<PCAPdata> finalFreq = new ArrayList<PCAPdata>();
   private HashMap<String, PCAPdata> finalMap = new HashMap<String, PCAPdata>();
-  private PCAPDao data = new PCAPDaoImpl();
   private String myip = "";
   private String filename;  
   private boolean first = true;
 
-  public FrequencyDaoImpl(String file) { 
-      this.filename = file;
+  public FrequencyDaoImpl(ArrayList<PCAPdata> packets) {
+    allPCAP = packets; 
   }
 
   /* Retrieve all necessary entities, processes, and puts into final arraylist */
-  public void loadFrequency() throws IOException {
-    allPCAP = data.getPCAPObjects(filename);
+  public void loadFrequency() {
     findMyIP();
     processData();
     putFinalFreq();
@@ -78,7 +76,10 @@ public class FrequencyDaoImpl implements FrequencyDao {
     // find largest recurrence
     String key = Collections.max(hm.entrySet(), Map.Entry.comparingByValue()).getKey();
     myip = key;
-    System.out.println("MYIP: " + myip);
+  }
+
+  public String getMyIP() {
+    return myip;
   }
 
   /* Fills out finalMap with frequencies based on IP address only (not protocol). */

--- a/src/main/java/com/google/netpcapanalysis/dao/FrequencyDaoImpl.java
+++ b/src/main/java/com/google/netpcapanalysis/dao/FrequencyDaoImpl.java
@@ -1,0 +1,126 @@
+package com.google.netpcapanalysis.dao;
+
+import com.google.netpcapanalysis.models.Flagged;
+import com.google.netpcapanalysis.models.PCAPdata;
+import java.util.*; 
+import java.io.*;
+import java.lang.*;
+
+import io.pkts.PacketHandler;
+import io.pkts.Pcap;
+import io.pkts.buffer.Buffer;
+import io.pkts.packet.Packet;
+import io.pkts.packet.TCPPacket;
+import io.pkts.packet.UDPPacket;
+import io.pkts.packet.IPPacket;
+import io.pkts.protocol.Protocol;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+
+import com.google.netpcapanalysis.interfaces.dao.PCAPDao;
+import com.google.netpcapanalysis.interfaces.dao.PCAPParserDao;
+import com.google.netpcapanalysis.interfaces.dao.FrequencyDao;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class FrequencyDaoImpl implements FrequencyDao {
+  private ArrayList<PCAPdata> allPCAP = new ArrayList<PCAPdata>(); 
+  private ArrayList<PCAPdata> finalFreq = new ArrayList<PCAPdata>();
+  private HashMap<String, PCAPdata> finalMap = new HashMap<String, PCAPdata>();
+  private PCAPDao data = new PCAPDaoImpl();
+  private String myip = "";
+  private String filename;  
+  private boolean first = true;
+
+  public FrequencyDaoImpl(String file) { 
+      this.filename = file;
+  }
+
+  /* Retrieve all necessary entities, processes, and puts into final arraylist */
+  public void loadFrequency() throws IOException {
+    allPCAP = data.getPCAPObjects(filename);
+    findMyIP();
+    processData();
+    putFinalFreq();
+  }
+
+  public ArrayList<PCAPdata> getAllPCAP() {
+    return allPCAP;
+  }
+
+  /* Find local ip address based on highest recurring IP address */
+  private void findMyIP() {
+    HashMap<String, Integer> hm = new HashMap<String, Integer>();
+    for (PCAPdata packet : allPCAP) {
+      // source
+      if (hm.containsKey(packet.source)) { 
+        // if IP already exists, increment
+        hm.merge(packet.source, 1, Integer::sum);
+      }
+      else {
+        hm.put(packet.source, 1);
+      }
+      // destination
+      if (hm.containsKey(packet.destination)) { 
+        // if IP already exists, increment
+        hm.merge(packet.destination, 1, Integer::sum);
+      }
+      else {
+        hm.put(packet.destination, 1);
+      }
+    }
+    // find largest recurrence
+    String key = Collections.max(hm.entrySet(), Map.Entry.comparingByValue()).getKey();
+    myip = key;
+    System.out.println("MYIP: " + myip);
+  }
+
+  /* Fills out finalMap with frequencies based on IP address only (not protocol). */
+  private void processData(){
+    for (PCAPdata packet : allPCAP) {
+      String outip = "";
+      String srcip = packet.source;
+      String dstip = packet.destination;
+
+      if (srcip == myip) {
+        outip = dstip;
+      }
+      else {
+        outip = srcip;
+      }
+      
+      // PCAPdata takes in (source, destination, domain, location, protocol, size, flagged, frequency) 
+      if (finalMap.containsKey(outip)){
+        // retrieve current value with outip and increments frequency
+        PCAPdata currPCAP = finalMap.get(outip);
+        currPCAP.incrementFrequency();
+      }
+      else {
+        PCAPdata tempPCAP = new PCAPdata(myip, outip, "", "", packet.protocol, packet.size, packet.flagged, packet.frequency); 
+        finalMap.put(outip, packet);
+      }
+    }
+  }
+
+  public HashMap<String, PCAPdata> getFinalMap() {
+    return finalMap;
+  }
+
+  /* Transfers all unique connections to an arraylist for return. */
+  private void putFinalFreq() {
+    for (PCAPdata packet : finalMap.values()) {
+      finalFreq.add(packet);
+    }
+  }
+
+  public ArrayList<PCAPdata> getFinalFreq() {
+    return finalFreq;
+  }
+
+}

--- a/src/main/java/com/google/netpcapanalysis/dao/PCAPParserDaoImpl.java
+++ b/src/main/java/com/google/netpcapanalysis/dao/PCAPParserDaoImpl.java
@@ -39,11 +39,11 @@ import java.nio.file.Paths;
 public class PCAPParserDaoImpl implements PCAPParserDao {
   private final DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
   private ArrayList<PCAPdata> allPCAP = new ArrayList<PCAPdata>(); 
-  private HashMap<String, PCAPdata> finalPCAP = new HashMap<String, PCAPdata>();
+  //private HashMap<String, PCAPdata> finalPCAP = new HashMap<String, PCAPdata>();
 
   private String filename;
-  private String myip = "";
-  private boolean first = true;
+  /*private String myip = "";
+  private boolean first = true;*/
 
   public PCAPParserDaoImpl(String file) { 
       this.filename = file;
@@ -70,12 +70,6 @@ public class PCAPParserDaoImpl implements PCAPParserDao {
 
         String protocol = getProtocol(ip); 
 
-        // myip to be the IP address of the local machine used to capture PCAP file
-        if (first) {
-            myip = srcip;
-            first = false;
-        }
-        
         // PCAPdata takes in (source, destination, domain, location, protocol, size, flagged, frequency) 
         PCAPdata rawPCAP = new PCAPdata(srcip, dstip, "", "", protocol, size, Flagged.UNKNOWN, 1);
         allPCAP.add(rawPCAP);
@@ -128,36 +122,9 @@ public class PCAPParserDaoImpl implements PCAPParserDao {
     return protocol;
   }
  
-  /* Removes duplicated data and increments corresponding frequencies */
-  public void processData(){
-    for (PCAPdata packet : allPCAP) {
-      String outip = "";
-      String srcip = packet.source;
-      String dstip = packet.destination;
-
-      if (srcip == myip) {
-        outip = dstip;
-      }
-      else {
-        outip = srcip;
-      }
-      
-      // PCAPdata takes in (source, destination, domain, location, protocol, size, flagged, frequency) 
-      if (finalPCAP.containsKey(outip)){
-        // retrieve current value with outip and increments frequency
-        PCAPdata currPCAP = finalPCAP.get(outip);
-        currPCAP.incrementFrequency();
-      }
-      else {
-        PCAPdata tempPCAP = new PCAPdata(myip, outip, "", "", packet.protocol, packet.size, packet.flagged, packet.frequency); 
-        finalPCAP.put(outip, packet);
-      }
-    }
-  }
-
-  /* Adds all processed packets to datastore through GenericPCAPDao*/
+  /* Adds all raw packets to datastore through GenericPCAPDao*/
   public void putDatastore(){
-    for (PCAPdata packet : finalPCAP.values()) {
+    for (PCAPdata packet : allPCAP) {
       PCAPDao data = new PCAPDaoImpl();
       data.setPCAPObjects(packet, filename);
     }
@@ -167,8 +134,5 @@ public class PCAPParserDaoImpl implements PCAPParserDao {
   public ArrayList<PCAPdata> getAllPCAP() {
     return allPCAP;
   }
-
-  public HashMap<String, PCAPdata> getFinalPCAP() {
-    return finalPCAP;
-  }
+  
 }

--- a/src/main/java/com/google/netpcapanalysis/interfaces/dao/FrequencyDao.java
+++ b/src/main/java/com/google/netpcapanalysis/interfaces/dao/FrequencyDao.java
@@ -4,8 +4,9 @@ import com.google.netpcapanalysis.models.PCAPdata;
 import java.util.*; 
 import java.io.*;
 
-public interface PCAPParserDao {
-    public void parseRaw() throws IOException;
-    public void putDatastore();
+public interface FrequencyDao {
+    public void loadFrequency() throws IOException;
     public ArrayList<PCAPdata> getAllPCAP();
+    public HashMap<String, PCAPdata> getFinalMap();
+    public ArrayList<PCAPdata> getFinalFreq();
 }

--- a/src/main/java/com/google/netpcapanalysis/interfaces/dao/FrequencyDao.java
+++ b/src/main/java/com/google/netpcapanalysis/interfaces/dao/FrequencyDao.java
@@ -5,8 +5,9 @@ import java.util.*;
 import java.io.*;
 
 public interface FrequencyDao {
-    public void loadFrequency() throws IOException;
+    public void loadFrequency();
     public ArrayList<PCAPdata> getAllPCAP();
     public HashMap<String, PCAPdata> getFinalMap();
     public ArrayList<PCAPdata> getFinalFreq();
+    public String getMyIP();
 }

--- a/src/main/java/com/google/netpcapanalysis/servlets/FrequencyLoaderServlet.java
+++ b/src/main/java/com/google/netpcapanalysis/servlets/FrequencyLoaderServlet.java
@@ -56,10 +56,11 @@ import java.io.*;
 @WebServlet("/PCAP-freq-loader")
 public class FrequencyLoaderServlet extends HttpServlet {
   private String filename;
+  private PCAPDao data = new PCAPDaoImpl();
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    FrequencyDao freq = new FrequencyDaoImpl(filename);
+    FrequencyDao freq = new FrequencyDaoImpl(data.getPCAPObjects(filename));
     freq.loadFrequency();
     ArrayList<PCAPdata> finalFrequencies = freq.getFinalFreq(); 
 

--- a/src/main/java/com/google/netpcapanalysis/servlets/FrequencyLoaderServlet.java
+++ b/src/main/java/com/google/netpcapanalysis/servlets/FrequencyLoaderServlet.java
@@ -22,6 +22,9 @@ import com.google.netpcapanalysis.interfaces.dao.PCAPDao;
 import com.google.netpcapanalysis.dao.PCAPParserDaoImpl;
 import com.google.netpcapanalysis.interfaces.dao.PCAPParserDao;
 
+import com.google.netpcapanalysis.dao.FrequencyDaoImpl;
+import com.google.netpcapanalysis.interfaces.dao.FrequencyDao;
+
 import io.pkts.PacketHandler;
 import io.pkts.Pcap;
 import io.pkts.buffer.Buffer;
@@ -49,23 +52,26 @@ import com.google.gson.Gson;
 import java.io.IOException;
 import java.io.*;
 
-/** Servlet that loads specific data from datastore */
-@WebServlet("/PCAP-loader")
-public class PacketLoaderServlet extends HttpServlet {
-  private String FILENAME;
-  private PCAPDao data = new PCAPDaoImpl();
+/** Servlet that retrieves and returns frequencies. */
+@WebServlet("/PCAP-freq-loader")
+public class FrequencyLoaderServlet extends HttpServlet {
+  private String filename;
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String json = convertToJsonUsingGson(data.getPCAPObjects(FILENAME));
+    FrequencyDao freq = new FrequencyDaoImpl(filename);
+    freq.loadFrequency();
+    ArrayList<PCAPdata> finalFrequencies = freq.getFinalFreq(); 
+
+    String json = convertToJsonUsingGson(finalFrequencies);
     response.setContentType("application/json;");
-    response.getWriter().println(json);
+    response.getWriter().println(json); 
   }
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    FILENAME = getParameter(request, "file-input", "");
-    response.sendRedirect("/network.html"); // is there a way to put down the website that sent the request?
+    filename = getParameter(request, "file-input", "");
+    response.sendRedirect("/network.html");
   }
 
   private String convertToJsonUsingGson(ArrayList<PCAPdata> data) {

--- a/src/main/java/com/google/netpcapanalysis/servlets/PacketParserServlet.java
+++ b/src/main/java/com/google/netpcapanalysis/servlets/PacketParserServlet.java
@@ -49,7 +49,7 @@ import com.google.gson.Gson;
 import java.io.IOException;
 import java.io.*;
 
-/** Servlet that processes raw PCAP files within the repo and puts data to Datastore by calling PCAPParserDao. */
+/** Servlet that puts raw PCAP files to Datastore by calling PCAPParserDao. */
 @WebServlet("/PCAP-data")
 public class PacketParserServlet extends HttpServlet {
   HashMap<String, PCAPdata> allPCAP = new HashMap<String, PCAPdata>();
@@ -57,12 +57,10 @@ public class PacketParserServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    // Retrieve user input to determine file name and local IP address.
+    // Retrieve user input to determine file name.
     String file = getParameter(request, "file-input", "");
-   
     PCAPParserDao parser = new PCAPParserDaoImpl(file);
     parser.parseRaw();
-    parser.processData();
     parser.putDatastore(); 
 
     // Respond with the result.

--- a/src/main/tests/dao/FrequencyDaoImplTest.java
+++ b/src/main/tests/dao/FrequencyDaoImplTest.java
@@ -28,8 +28,8 @@ import java.net.URL;
 
 /* Compares file2.pcap's parsed results to hard-coded results. IP1 and IP2 addresses are located in hidden text file and retrieved as a stream. */
 public class FrequencyDaoImplTest {
-  public FrequencyDao freq;
-  public String PCAPNAME = "files/file2.pcap";
+  private FrequencyDao freq;
+  private String PCAPNAME = "files/file2.pcap";
   private String FILENAME = "files/file2.txt";
 
   private String IP1;

--- a/src/main/tests/dao/FrequencyDaoImplTest.java
+++ b/src/main/tests/dao/FrequencyDaoImplTest.java
@@ -1,0 +1,84 @@
+package dao;
+
+import static org.junit.Assert.assertEquals;
+import com.google.netpcapanalysis.dao.PCAPParserDaoImpl;
+import com.google.netpcapanalysis.interfaces.dao.PCAPParserDao;
+
+import com.google.netpcapanalysis.models.PCAPdata;
+
+import com.google.netpcapanalysis.dao.PCAPDaoImpl;
+import com.google.netpcapanalysis.interfaces.dao.PCAPDao;
+
+import com.google.netpcapanalysis.dao.FrequencyDaoImpl;
+import com.google.netpcapanalysis.interfaces.dao.FrequencyDao;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*; 
+import java.io.*;
+import java.lang.*;
+
+import org.apache.commons.io.IOUtils;
+import java.nio.charset.StandardCharsets;
+import java.net.URL; 
+
+/* Compares file2.pcap's parsed results to hard-coded results. IP1 and IP2 addresses are located in hidden text file and retrieved as a stream. */
+public class FrequencyDaoImplTest {
+  public FrequencyDao freq;
+  public String PCAPNAME = "files/file2.pcap";
+  private String FILENAME = "files/file2.txt";
+
+  private String IP1;
+  private String IP2;
+  private String UDP = "UDP";
+  private int FREQ = 2;
+  private int SIZE = 2;
+
+  @Before
+  public void setup() throws IOException {
+    // Parse set IP addresses from hidden text file
+    Path path = Paths.get(FILENAME);
+    InputStream stream = PCAPParserDaoImplTest.class.getClassLoader().getResourceAsStream(path.toString());
+    System.out.println("Path: " + path.toString());  
+    
+    String text = IOUtils.toString(stream, StandardCharsets.UTF_8);
+    String[] values = text.split(",");
+    IP1 = values[0];
+    IP2 = values[1];
+
+    // Generate frequency information
+    ArrayList<PCAPdata> data = new ArrayList<PCAPdata>();
+    PCAPdata tempPCAP1 = new PCAPdata(IP1, IP2, "", "", UDP, SIZE, "false", FREQ);
+    data.add(tempPCAP1);
+
+    PCAPdata tempPCAP2 = new PCAPdata(IP2, IP1, "", "", UDP, SIZE, "false", FREQ);
+    data.add(tempPCAP2);
+
+    PCAPdata tempPCAP3 = new PCAPdata(IP1, IP1, "", "", UDP, SIZE, "false", FREQ);
+    data.add(tempPCAP3);
+
+    freq = new FrequencyDaoImpl(data);
+    freq.loadFrequency();
+  }
+
+  /* Checks the most recurrent IP address */
+  @Test
+  public void testMyIP() {
+    String myip = freq.getMyIP();
+    assertEquals(myip, IP1);
+  }
+
+  /* Checks number of unique packets. */
+  @Test
+  public void testDuplicates() {
+    HashMap<String, PCAPdata> finalMap = freq.getFinalMap();
+    int size = finalMap.size();
+    int comparison = SIZE;
+    assertEquals(size, 2); // there should only be 2 unique connections: IP1/IP2 and IP1/IP1
+  }
+
+}

--- a/src/main/tests/dao/FrequencyDaoImplTest.java
+++ b/src/main/tests/dao/FrequencyDaoImplTest.java
@@ -29,6 +29,8 @@ import java.net.URL;
 /* Compares file2.pcap's parsed results to hard-coded results. IP1 and IP2 addresses are located in hidden text file and retrieved as a stream. */
 public class FrequencyDaoImplTest {
   private FrequencyDao freq;
+  private ArrayList<PCAPdata> data;
+
   private String PCAPNAME = "files/file2.pcap";
   private String FILENAME = "files/file2.txt";
 
@@ -43,7 +45,6 @@ public class FrequencyDaoImplTest {
     // Parse set IP addresses from hidden text file
     Path path = Paths.get(FILENAME);
     InputStream stream = PCAPParserDaoImplTest.class.getClassLoader().getResourceAsStream(path.toString());
-    System.out.println("Path: " + path.toString());  
     
     String text = IOUtils.toString(stream, StandardCharsets.UTF_8);
     String[] values = text.split(",");
@@ -51,7 +52,7 @@ public class FrequencyDaoImplTest {
     IP2 = values[1];
 
     // Generate frequency information
-    ArrayList<PCAPdata> data = new ArrayList<PCAPdata>();
+    data = new ArrayList<PCAPdata>();
     PCAPdata tempPCAP1 = new PCAPdata(IP1, IP2, "", "", UDP, SIZE, "false", FREQ);
     data.add(tempPCAP1);
 
@@ -65,7 +66,14 @@ public class FrequencyDaoImplTest {
     freq.loadFrequency();
   }
 
-  /* Checks the most recurrent IP address */
+  /* Checks all packets have been put properly. */
+  @Test
+  public void testAllPCAP() {
+    ArrayList<PCAPdata> allPCAP = freq.getAllPCAP();
+    assertEquals(allPCAP, data);
+  }
+
+  /* Checks the most recurrent IP address. */
   @Test
   public void testMyIP() {
     String myip = freq.getMyIP();
@@ -78,7 +86,16 @@ public class FrequencyDaoImplTest {
     HashMap<String, PCAPdata> finalMap = freq.getFinalMap();
     int size = finalMap.size();
     int comparison = SIZE;
-    assertEquals(size, 2); // there should only be 2 unique connections: IP1/IP2 and IP1/IP1
+    assertEquals(size, comparison); // there should only be 2 unique connections: IP1/IP2 and IP1/IP1
+  }
+
+  /* Checks number of final nodes. */
+  @Test
+  public void testFinalNodes() {
+    ArrayList<PCAPdata> finalFreq = freq.getFinalFreq();
+    int size = finalFreq.size();
+    int comparison = SIZE;
+    assertEquals(size, comparison); // there should only be 2 nodes: IP1 and IP2
   }
 
 }

--- a/src/main/tests/dao/PCAPParserDaoImplTest.java
+++ b/src/main/tests/dao/PCAPParserDaoImplTest.java
@@ -49,7 +49,6 @@ public class PCAPParserDaoImplTest {
     // Retrieve PCAPParser information
     parser = new PCAPParserDaoImpl(PCAPNAME);
     parser.parseRaw();
-    parser.processData();
   }
 
   @Test
@@ -104,24 +103,6 @@ public class PCAPParserDaoImplTest {
 
     // compare
     assertEquals(protocols, comparison);
-  }
-
-  /* Verify that the frequency of connections has been properly incremented after data has been processed. */
-  @Test
-  public void testFrequency() {
-    HashMap<String, PCAPdata> finalPCAP = parser.getFinalPCAP();
-    int frequency = finalPCAP.get(IP2).getFrequency();
-    int comparison = FREQ;
-    assertEquals(frequency, comparison);
-  }
-
-  /* Checks number of unique packets. */
-  @Test
-  public void testDuplicates() {
-    HashMap<String, PCAPdata> finalPCAP = parser.getFinalPCAP();
-    int size = finalPCAP.size();
-    int comparison = SIZE;
-    assertEquals(size, comparison);
   }
 
 }

--- a/src/main/tests/dao/PCAPParserDaoImplTest.java
+++ b/src/main/tests/dao/PCAPParserDaoImplTest.java
@@ -38,8 +38,6 @@ public class PCAPParserDaoImplTest {
     // Parse set IP addresses from hidden text file
     Path path = Paths.get(FILENAME);
     InputStream stream = PCAPParserDaoImplTest.class.getClassLoader().getResourceAsStream(path.toString());
-    System.out.println("Path: " + path.toString());  //InputStream stream = PCAPParserDaoImplTest.class.getResourceAsStream(path.toString());
-    //InputStream stream = this.getClass().getResourceAsStream(FILENAME);
     
     String text = IOUtils.toString(stream, StandardCharsets.UTF_8);
     String[] values = text.split(",");

--- a/src/main/webapp/js/network.js
+++ b/src/main/webapp/js/network.js
@@ -1,7 +1,7 @@
 const SOURCE = 0;
 const SHAPE = "dot"
 const SHAPE_SIZE = 16;
-const EDGE_LIMIT = 15; // limit the number of edges on visualization 
+const EDGE_LIMIT = 20; // limit the number of edges on visualization 
 
 const GROUP1 = 1;
 const GROUP2 = 2;
@@ -15,10 +15,9 @@ const MAX_VEL = 30;
 const TIMESTEP = 0.35;
 const ITER = 200; 
 const OVERLAP_CONST = 1;
-const CLUSTER_SIZE = 5;
 
-/** Create basic visualization network graph based on data in datastore without descriptive labels.*/
-function drawNetwork(){
+/** Create visualization network graph based on IPs. */
+function createIPNetwork(){
   fetch('/PCAP-freq-loader') // retrieve all Datastore data that has "data" label
   .then(response => response.json())
   .then((data) => {
@@ -35,56 +34,102 @@ function drawNetwork(){
     var edge = 0;
     nodes[SOURCE] = {id: SOURCE, label: title, group: SOURCE}; 
     
-    if (num_nodes > CLUSTER_SIZE) {
-      populateLargeGraph();
-      createNetwork();
-    }
-    else {
-      populateSmallGraph();
-      createNetwork();
-    }
-
-    /* Populate nodes and edges with the following formatting:
-     ** NODE: {id: ID, label: LABEL, group: GROUP} 
-     ** EDGE: {from: SOURCE, to: DESTINATION}
-    */
-    function populateLargeGraph(){
-      // layer 1
-      helper(SOURCE);
-
-      // layer 2
-      for (var i = 1; i <= CLUSTER_SIZE; i++) {
-        helper(i);
-      }
-
-      // layer 3 -- maximum of 125 nodes on the graph (with CLUSTER_SIZE of 5) since graph slows with more nodes
-      for (var j = CLUSTER_SIZE+1; j <= Math.pow(CLUSTER_SIZE, 2); j++) {
-        helper(j);
-      }
-
-      function helper(node) {
-        for (var i = 0; i < CLUSTER_SIZE; i++) { 
-          curr++;
-          if (curr < num_nodes) {
-            nodes[curr] = {id: curr, label: "Node " + curr, group: curr%CLUSTER_SIZE};
-            for (var j = 0; j < EDGE_LIMIT && j < data[curr].frequency; j++) { 
-              edges[edge] = {from: node, to: curr};
-              edge++;
-           }
-          }
-        }
-      }
-    } // end large graph
+    populateSmallGraph();
+    createNetwork();
 
     function populateSmallGraph(){
       for (var n = 1; n < data.length+1; n++) {
-        nodes[n] = {id: n, label: "Node " + n, group: n};
-        for (var m = 0; m < data[n-1].frequency; m++) {
-            edges[edge] = {from: SOURCE, to: n};
-            edge++;
+        nodes[n] = {id: n, label: data[n-1].destination + "\n" + data[n-1].frequency + " Connections", group: n};
+        // take normalized frequency
+        var normaled = normalize(data[n-1].frequency);
+        for (var m = 0; m < normaled; m++) {
+          edges[edge] = {from: n, to: SOURCE};
+          edge++;
         }
       }
     } // end small graph
+
+    // normalize frequency on a scale from 1 to EDGE_LIMIT
+    function normalize(m){
+      var max = data[0].frequency; //largest frequency
+      var min = data[data.length-1].frequency; //smallest frequency
+      return ((m - min) / (max - min) * EDGE_LIMIT + 1);
+    }
+
+    /* Initialize network based on nodes and edges. */
+    function createNetwork(){
+      var container = document.getElementById("mynetwork");
+
+      var finalData = {
+        nodes: nodes,
+        edges: edges,
+      };
+
+      var options = {
+        nodes: {
+          shape: SHAPE,
+          size: SHAPE_SIZE,
+        },
+        physics: {
+          forceAtlas2Based: {
+            gravitationalConstant: GRAV_CONSTANT,
+            centralGravity: CENTRAL_GRAV,
+            springLength: SPRING_LENGTH,
+            springConstant: SPRING_CONST,
+            avoidOverlap: OVERLAP_CONST,
+        },
+        maxVelocity: MAX_VEL,
+        solver: "forceAtlas2Based",
+        timestep: TIMESTEP,
+        stabilization: { iterations: ITER },
+        },
+      };
+      network = new vis.Network(container, finalData, options);
+    }
+    
+    window.addEventListener("load", () => {draw();});
+  });
+} // end IP network
+
+/** Create visualization network graph based on data in datastore without descriptive labels.*/
+function drawObfusNetwork(){
+  fetch('/PCAP-freq-loader') // retrieve all Datastore data that has "data" label
+  .then(response => response.json())
+  .then((data) => {
+  
+    // initialize nodes and edges arrays
+    var nodes = new Array();
+    var edges = new Array();
+
+    var num_nodes = data.length;
+    var title = "My Computer";
+
+    // add source node
+    var curr = SOURCE;
+    var edge = 0;
+    nodes[SOURCE] = {id: SOURCE, label: title, group: SOURCE}; 
+    
+    populateSmallGraph();
+    createNetwork();
+
+    function populateSmallGraph(){
+      for (var n = 1; n < data.length+1; n++) {
+        nodes[n] = {id: n, label: "Node: " + n + "\n" + data[n-1].frequency + " Connections", group: n};
+        // take normalized frequency
+        var normaled = normalize(data[n-1].frequency);
+        for (var m = 0; m < normaled; m++) {
+          edges[edge] = {from: n, to: SOURCE};
+          edge++;
+        }
+      }
+    } // end small graph
+
+    // normalize frequency on a scale from 1 to EDGE_LIMIT
+    function normalize(m){
+      var max = data[0].frequency; //largest frequency
+      var min = data[data.length-1].frequency; //smallest frequency
+      return ((m - min) / (max - min) * EDGE_LIMIT + 1);
+    }
 
     /* Initialize network based on nodes and edges. */
     function createNetwork(){

--- a/src/main/webapp/js/network.js
+++ b/src/main/webapp/js/network.js
@@ -18,7 +18,7 @@ const OVERLAP_CONST = 1;
 
 /** Create visualization network graph based on IPs. */
 function createIPNetwork(){
-  fetch('/PCAP-freq-loader') // retrieve all Datastore data that has "data" label
+  fetch('/PCAP-freq-loader') // retrieve all Datastore data that has proper label
   .then(response => response.json())
   .then((data) => {
   
@@ -93,7 +93,7 @@ function createIPNetwork(){
 
 /** Create visualization network graph based on data in datastore without descriptive labels.*/
 function drawObfusNetwork(){
-  fetch('/PCAP-freq-loader') // retrieve all Datastore data that has "data" label
+  fetch('/PCAP-freq-loader') 
   .then(response => response.json())
   .then((data) => {
   

--- a/src/main/webapp/js/network.js
+++ b/src/main/webapp/js/network.js
@@ -18,8 +18,8 @@ const OVERLAP_CONST = 1;
 const CLUSTER_SIZE = 5;
 
 /** Create basic visualization network graph based on data in datastore without descriptive labels.*/
-function createNetwork(){
-  fetch('/PCAP-loader') // retrieve all Datastore data that has "data" label
+function drawNetwork(){
+  fetch('/PCAP-freq-loader') // retrieve all Datastore data that has "data" label
   .then(response => response.json())
   .then((data) => {
   
@@ -77,9 +77,9 @@ function createNetwork(){
     } // end large graph
 
     function populateSmallGraph(){
-      for (var n = 1; n < data.length; n++) {
+      for (var n = 1; n < data.length+1; n++) {
         nodes[n] = {id: n, label: "Node " + n, group: n};
-        for (var m = 0; m < data[n].frequency; m++) {
+        for (var m = 0; m < data[n-1].frequency; m++) {
             edges[edge] = {from: SOURCE, to: n};
             edge++;
         }

--- a/src/main/webapp/network.html
+++ b/src/main/webapp/network.html
@@ -17,7 +17,7 @@
 
   <!-- Custom styles for this template-->
   <link href="css/sb-admin-2.min.css" rel="stylesheet">
-  <link href="css/network.css" rel"stylesheet">
+  <link href="css/network.css" rel="stylesheet">
 
 </head>
 
@@ -153,10 +153,10 @@
 
           <br/><br/>
           <p>Now that you've chosen a file, take a look at the network visualization.</p>
-          <button onclick="drawNetwork()">View Network</button>
+          <button onclick="drawObfusNetwork()">Obfuscated Network</button><button onclick="createIPNetwork()">IP Network</button>
           <br/><br/>
           <div style="height: 100vh", id="mynetwork"></div>
-          <!-- End Network Example style="height: 75%; width: 100%",  -->
+          <!-- End Network Example -->
           
     </div>
     <!-- End of Main Content -->

--- a/src/main/webapp/network.html
+++ b/src/main/webapp/network.html
@@ -144,7 +144,7 @@
 
           <p class="mb-4">Example network visualization with data from data.csv (loaded from the <a href="tables.html">tables</a> page). Check out <a href="https://visjs.github.io/vis-network/examples/">this</a> library to see the source code. Enter a filename, submit, then click to view!</p>
           
-          <form action="/PCAP-loader" method="POST">
+          <form action="/PCAP-freq-loader" method="POST">
             <p>Choose a file to view:</p>
             <textarea name="file-input">files/file1.pcap</textarea>
             <br/>
@@ -153,7 +153,7 @@
 
           <br/><br/>
           <p>Now that you've chosen a file, take a look at the network visualization.</p>
-          <button onclick="createNetwork()">View Network</button>
+          <button onclick="drawNetwork()">View Network</button>
           <br/><br/>
           <div style="height: 100vh", id="mynetwork"></div>
           <!-- End Network Example style="height: 75%; width: 100%",  -->


### PR DESCRIPTION
# Description

- Added FrequencyDao and FrequencyDaoImpl to separate data parsing and data processing
- depicting top number of frequencies
- Normalizing number of edges in JS visualization (for visibility)
- Included FrequencyDaoImpl tests to check packets in PCAP file are being counted correctly 

# Checklist:

- [x] Code follows the style guidelines
- [x] Code commented in relevant places
- [x] Changes to necessary documentation made
- [x] Has test cases for code.

# Tests Performed:

- [x] Upload data to Datastore
- [x] Retreive data from Datastore
- [x] Map Visualization 
- [x] Network Map Visualization 
- [x] List other manual test cases performed
