### PR TITLE
Refactoring frequency calculations

### DIFF
--- a/src/main/java/com/google/netpcapanalysis/dao/FrequencyDaoImpl.java
+++ b/src/main/java/com/google/netpcapanalysis/dao/FrequencyDaoImpl.java
@@ -37,7 +37,6 @@ public class FrequencyDaoImpl implements FrequencyDao {
 
   private String myip = "";
   private boolean first = true;
-  private int NUM_NODES = 15;
 
   public FrequencyDaoImpl(ArrayList<PCAPdata> packets) {
     allPCAP = packets; 
@@ -80,8 +79,8 @@ public class FrequencyDaoImpl implements FrequencyDao {
 
   /* Fills out finalMap with frequencies based on IP address only (not protocol). */
   private void processData(){
-    LinkedHashMap<String, Integer> hm = getUniqueOutIPs();
-    getFrequentIPs(hm);
+    //LinkedHashMap<String, Integer> hm = getUniqueOutIPs();
+    getFrequentIPs(getUniqueOutIPs());
   } 
   
   /* Sort IPs by frequency and get most frequent addresses*/
@@ -95,21 +94,11 @@ public class FrequencyDaoImpl implements FrequencyDao {
       }
     });
 
-    if (entries.size() < NUM_NODES) {
-      finalMap = hm;
+    finalMap = new LinkedHashMap<String, Integer>();
+    for(Map.Entry<String, Integer> map : entries){
+      finalMap.put(map.getKey(), map.getValue());
     }
-    else {
-      finalMap = new LinkedHashMap<String, Integer>();
-      // add top NUM_NODE frequencies
-      int counter = 0;
-      for(Map.Entry<String, Integer> map : entries){
-        if (counter < NUM_NODES) {
-          finalMap.put(map.getKey(), map.getValue());
-          counter++;
-        }
-      }
-    }
-    
+
   }
 
   /* Gets all unique outgoing IPs and puts OUTIP as key in hashmap, where value represents frequency */

--- a/src/main/java/com/google/netpcapanalysis/dao/FrequencyDaoImpl.java
+++ b/src/main/java/com/google/netpcapanalysis/dao/FrequencyDaoImpl.java
@@ -86,7 +86,6 @@ public class FrequencyDaoImpl implements FrequencyDao {
   
   /* Sort IPs by frequency and get most frequent addresses*/
   private void getFrequentIPs(LinkedHashMap<String, Integer> hm) {
-    finalMap = new LinkedHashMap<String, Integer>();
     Set<Map.Entry<String, Integer>> set = hm.entrySet();
     List<Map.Entry<String, Integer>> entries = new ArrayList<Map.Entry<String, Integer>>(set);
     Collections.sort(entries, new Comparator<Map.Entry<String, Integer>>() {
@@ -95,15 +94,22 @@ public class FrequencyDaoImpl implements FrequencyDao {
         return e2.getValue().compareTo(e1.getValue()); // reverse order
       }
     });
-    
-    // add top NUM_NODE frequencies
-    int counter = 0;
-    for(Map.Entry<String, Integer> map : entries){
-      if (counter < NUM_NODES) {
-        finalMap.put(map.getKey(), map.getValue());
-        counter++;
+
+    if (entries.size() < NUM_NODES) {
+      finalMap = hm;
+    }
+    else {
+      finalMap = new LinkedHashMap<String, Integer>();
+      // add top NUM_NODE frequencies
+      int counter = 0;
+      for(Map.Entry<String, Integer> map : entries){
+        if (counter < NUM_NODES) {
+          finalMap.put(map.getKey(), map.getValue());
+          counter++;
+        }
       }
     }
+    
   }
 
   /* Gets all unique outgoing IPs and puts OUTIP as key in hashmap, where value represents frequency */

--- a/src/main/java/com/google/netpcapanalysis/interfaces/dao/FrequencyDao.java
+++ b/src/main/java/com/google/netpcapanalysis/interfaces/dao/FrequencyDao.java
@@ -5,9 +5,7 @@ import java.util.*;
 import java.io.*;
 
 public interface FrequencyDao {
-    public void loadFrequency();
     public ArrayList<PCAPdata> getAllPCAP();
-    public HashMap<String, PCAPdata> getFinalMap();
-    public ArrayList<PCAPdata> getFinalFreq();
+    public LinkedHashMap<String, Integer> getFinalMap();
     public String getMyIP();
 }

--- a/src/main/java/com/google/netpcapanalysis/servlets/FrequencyLoaderServlet.java
+++ b/src/main/java/com/google/netpcapanalysis/servlets/FrequencyLoaderServlet.java
@@ -61,8 +61,7 @@ public class FrequencyLoaderServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     FrequencyDao freq = new FrequencyDaoImpl(data.getPCAPObjects(filename));
-    freq.loadFrequency();
-    ArrayList<PCAPdata> finalFrequencies = freq.getFinalFreq(); 
+    LinkedHashMap<String, Integer> finalFrequencies = freq.getFinalMap(); 
 
     String json = convertToJsonUsingGson(finalFrequencies);
     response.setContentType("application/json;");
@@ -75,7 +74,7 @@ public class FrequencyLoaderServlet extends HttpServlet {
     response.sendRedirect("/network.html");
   }
 
-  private String convertToJsonUsingGson(ArrayList<PCAPdata> data) {
+  private String convertToJsonUsingGson(LinkedHashMap<String, Integer> data) {
     Gson gson = new Gson();
     String json = gson.toJson(data);
     return json;

--- a/src/main/tests/dao/FrequencyDaoImplTest.java
+++ b/src/main/tests/dao/FrequencyDaoImplTest.java
@@ -63,7 +63,6 @@ public class FrequencyDaoImplTest {
     data.add(tempPCAP3);
 
     freq = new FrequencyDaoImpl(data);
-    freq.loadFrequency();
   }
 
   /* Checks all packets have been put properly. */
@@ -83,19 +82,19 @@ public class FrequencyDaoImplTest {
   /* Checks number of unique packets. */
   @Test
   public void testDuplicates() {
-    HashMap<String, PCAPdata> finalMap = freq.getFinalMap();
+    LinkedHashMap<String, Integer> finalMap = freq.getFinalMap();
     int size = finalMap.size();
     int comparison = SIZE;
     assertEquals(size, comparison); // there should only be 2 unique connections: IP1/IP2 and IP1/IP1
   }
 
-  /* Checks number of final nodes. */
-  @Test
-  public void testFinalNodes() {
-    ArrayList<PCAPdata> finalFreq = freq.getFinalFreq();
-    int size = finalFreq.size();
-    int comparison = SIZE;
-    assertEquals(size, comparison); // there should only be 2 nodes: IP1 and IP2
+  /* Checks frequencies of packets. */
+  @Test 
+  public void checkFrequentIPs() {
+    LinkedHashMap<String, Integer> finalMap = freq.getFinalMap();
+    int frequency = finalMap.get(IP2);
+    int comparison = FREQ;
+    assertEquals(frequency, comparison);
   }
 
 }

--- a/src/main/webapp/js/network.js
+++ b/src/main/webapp/js/network.js
@@ -2,6 +2,7 @@ const SOURCE = 0;
 const SHAPE = "dot"
 const SHAPE_SIZE = 16;
 const EDGE_LIMIT = 20; // limit the number of edges on visualization 
+const NODE_LIMIT = 20;
 
 const GROUP1 = 1;
 const GROUP2 = 2;
@@ -35,15 +36,19 @@ function createIPNetwork(){
     nodes[n] = {id: n, label: title, group: n};  
     n++;
 
+    var limit = 0;
     // put all addresses onto graph
     Object.keys(data).forEach(key => {
-      var normaled = normalize(data[key]);
-      nodes[n] = {id: n, label: key + "\n" + data[key] + " Connections", group: n}; // maybe coloring by class?
-      for (var m = 0; m < normaled; m++) {
-        edges[edge] = {from: n, to: SOURCE};
-        edge++;
+      if (limit < NODE_LIMIT) {
+        var normaled = normalize(data[key]);
+        nodes[n] = {id: n, label: key + "\n" + data[key] + " Connections", group: n}; // maybe coloring by class?
+        for (var m = 0; m < normaled; m++) {
+            edges[edge] = {from: n, to: SOURCE};
+            edge++;
+        }
+        n++;
       }
-      n++;
+      limit++;
     });
     
     createNetwork();
@@ -114,15 +119,19 @@ function drawObfusNetwork(){
     nodes[n] = {id: n, label: title, group: n}; 
     n++;
 
+    var limit = 0;
     // put all addresses onto graph
     Object.keys(data).forEach(key => {
-      var normaled = normalize(data[key]);
-      nodes[n] = {id: n, label: "Node " + n + "\n" + data[key] + " Connections", group: n};
-      for (var m = 0; m < normaled; m++) {
-        edges[edge] = {from: n, to: SOURCE};
-        edge++;
+      if (limit < NODE_LIMIT) {
+        var normaled = normalize(data[key]);
+        nodes[n] = {id: n, label: key + "\n" + data[key] + " Connections", group: n}; // maybe coloring by class?
+        for (var m = 0; m < normaled; m++) {
+            edges[edge] = {from: n, to: SOURCE};
+            edge++;
+        }
+        n++;
       }
-      n++;
+      limit++;
     });
     
     createNetwork();

--- a/src/main/webapp/js/network.js
+++ b/src/main/webapp/js/network.js
@@ -26,34 +26,38 @@ function createIPNetwork(){
     var nodes = new Array();
     var edges = new Array();
 
-    var num_nodes = data.length;
+    var num_nodes = Object.keys(data).length;
     var title = "My Computer";
 
     // add source node
-    var curr = SOURCE;
+    var n = SOURCE;
     var edge = 0;
-    nodes[SOURCE] = {id: SOURCE, label: title, group: SOURCE}; 
-    
-    populateSmallGraph();
-    createNetwork();
+    nodes[n] = {id: n, label: title, group: n};  
+    n++;
 
-    function populateSmallGraph(){
-      for (var n = 1; n < data.length+1; n++) {
-        nodes[n] = {id: n, label: data[n-1].destination + "\n" + data[n-1].frequency + " Connections", group: n};
-        // take normalized frequency
-        var normaled = normalize(data[n-1].frequency);
-        for (var m = 0; m < normaled; m++) {
-          edges[edge] = {from: n, to: SOURCE};
-          edge++;
-        }
+    // put all addresses onto graph
+    Object.keys(data).forEach(key => {
+      var normaled = normalize(data[key]);
+      nodes[n] = {id: n, label: key + "\n" + data[key] + " Connections", group: n}; // maybe coloring by class?
+      for (var m = 0; m < normaled; m++) {
+        edges[edge] = {from: n, to: SOURCE};
+        edge++;
       }
-    } // end small graph
+      n++;
+    });
+    
+    createNetwork();
 
     // normalize frequency on a scale from 1 to EDGE_LIMIT
     function normalize(m){
-      var max = data[0].frequency; //largest frequency
-      var min = data[data.length-1].frequency; //smallest frequency
-      return ((m - min) / (max - min) * EDGE_LIMIT + 1);
+      if (num_nodes > 1) {
+        var max = Object.keys(data)[0]; //largest frequency
+        var min = Object.keys(data)[num_nodes-1]; //smallest frequency
+        return ((m - data[min]) / (data[max] - data[min]) * EDGE_LIMIT + 1);
+      }
+      else {
+        return m;
+      }
     }
 
     /* Initialize network based on nodes and edges. */
@@ -93,7 +97,7 @@ function createIPNetwork(){
 
 /** Create visualization network graph based on data in datastore without descriptive labels.*/
 function drawObfusNetwork(){
-  fetch('/PCAP-freq-loader') 
+  fetch('/PCAP-freq-loader') // retrieve all Datastore data that has proper label
   .then(response => response.json())
   .then((data) => {
   
@@ -101,34 +105,38 @@ function drawObfusNetwork(){
     var nodes = new Array();
     var edges = new Array();
 
-    var num_nodes = data.length;
+    var num_nodes = Object.keys(data).length;
     var title = "My Computer";
 
     // add source node
-    var curr = SOURCE;
+    var n = SOURCE;
     var edge = 0;
-    nodes[SOURCE] = {id: SOURCE, label: title, group: SOURCE}; 
-    
-    populateSmallGraph();
-    createNetwork();
+    nodes[n] = {id: n, label: title, group: n}; 
+    n++;
 
-    function populateSmallGraph(){
-      for (var n = 1; n < data.length+1; n++) {
-        nodes[n] = {id: n, label: "Node: " + n + "\n" + data[n-1].frequency + " Connections", group: n};
-        // take normalized frequency
-        var normaled = normalize(data[n-1].frequency);
-        for (var m = 0; m < normaled; m++) {
-          edges[edge] = {from: n, to: SOURCE};
-          edge++;
-        }
+    // put all addresses onto graph
+    Object.keys(data).forEach(key => {
+      var normaled = normalize(data[key]);
+      nodes[n] = {id: n, label: "Node " + n + "\n" + data[key] + " Connections", group: n};
+      for (var m = 0; m < normaled; m++) {
+        edges[edge] = {from: n, to: SOURCE};
+        edge++;
       }
-    } // end small graph
+      n++;
+    });
+    
+    createNetwork();
 
     // normalize frequency on a scale from 1 to EDGE_LIMIT
     function normalize(m){
-      var max = data[0].frequency; //largest frequency
-      var min = data[data.length-1].frequency; //smallest frequency
-      return ((m - min) / (max - min) * EDGE_LIMIT + 1);
+      if (num_nodes > 1) {
+        var max = Object.keys(data)[0]; //largest frequency
+        var min = Object.keys(data)[num_nodes-1]; //smallest frequency
+        return ((m - data[min]) / (data[max] - data[min]) * EDGE_LIMIT + 1);
+      }
+      else {
+        return m;
+      }
     }
 
     /* Initialize network based on nodes and edges. */
@@ -164,4 +172,4 @@ function drawObfusNetwork(){
     
     window.addEventListener("load", () => {draw();});
   });
-} // end obfuscated 
+} // end obfuscated


### PR DESCRIPTION
# Description

Resolving issues from previous PR (see #49):
- Removed use of PCAPdata object from calculations (replaced with linked hashmap of outgoing IP address and frequency)
- Refactored `network.js` to visualize data from hashmap JSON rather than PCAPdata list
- Added new tests

# Checklist:

- [x] Code follows the style guidelines
- [x] Code commented in relevant places
- [x] Changes to necessary documentation made
- [x] Has test cases for code.

# Tests Performed:

- [x] Upload data to Datastore
- [x] Retreive data from Datastore
- [x] Map Visualization 
- [x] Network Map Visualization 
- [x] List other manual test cases performed
