### PR TITLE
Protocol IPv4 to Other

### DIFF
--- a/src/main/java/com/google/netpcapanalysis/dao/PCAPParserDaoImpl.java
+++ b/src/main/java/com/google/netpcapanalysis/dao/PCAPParserDaoImpl.java
@@ -78,7 +78,7 @@ public class PCAPParserDaoImpl implements PCAPParserDao {
     * Checks for the following protocols — ICMP, IGMP, TCP, UDP, SCTP, SIP, SDP, ETHERNET_II, SLL, IPv4, RTP —
     * which are the only protocols supported by pkts library. */
   private String getProtocol(IPPacket packet) throws IOException {
-    String protocol = "IPv4";
+    String protocol = "Other";
     // If packet has UDP or TCP protocol, fetch the port numbers (source/destination).
     if (packet.hasProtocol(Protocol.UDP)) {
       protocol = "UDP";

--- a/src/main/webapp/malicious.html
+++ b/src/main/webapp/malicious.html
@@ -155,7 +155,7 @@
 
           <!-- Nav Item - User Information -->
           <li class="nav-item dropdown no-arrow">
-            <a href="/domain.html" class="btn btn-primary btn-icon-split mr-2">
+            <a href="/domains.html" class="btn btn-primary btn-icon-split mr-2">
               <span class="icon text-white-50">
                 <i class="fas fa-arrow-left"></i>
               </span>

--- a/src/main/webapp/pcap-uploader.html
+++ b/src/main/webapp/pcap-uploader.html
@@ -167,7 +167,7 @@
                 <option value="files/p6.pcap">files/p6.pcap</option>
                 <option value="files/p9.pcap">files/p9.pcap</option>
                 <option value="files/p10.pcap">files/p10.pcap</option>
-                <option value="files/p10.pcap">files/nitroba-pcap.pcap</option>
+                <option value="files/nitroba-pcap.pcap">files/nitroba-pcap.pcap</option>
               </select>
               <br>
               <label for="description">Description:</label>

--- a/src/main/webapp/pcap-uploader.html
+++ b/src/main/webapp/pcap-uploader.html
@@ -167,6 +167,7 @@
                 <option value="files/p6.pcap">files/p6.pcap</option>
                 <option value="files/p9.pcap">files/p9.pcap</option>
                 <option value="files/p10.pcap">files/p10.pcap</option>
+                <option value="files/p10.pcap">files/nitroba-pcap.pcap</option>
               </select>
               <br>
               <label for="description">Description:</label>


### PR DESCRIPTION
# Description

Changed description of protocols so that if a specific protocol can't be found, the type is OTHER and not IPV4

# Checklist:

- [x] Code follows the style guidelines
- [x] Code commented in relevant places
- [x] Changes to necessary documentation made
- [x] Has test cases for code.

# Tests Performed:

- [x] Upload data to Datastore
- [x] Retreive data from Datastore
- [x] Map Visualization 
- [x] Network Map Visualization 
- [x] List other manual test cases performed
